### PR TITLE
Account for scenario where frame.name() returns None.

### DIFF
--- a/gdbDisplayLockedThreads.py
+++ b/gdbDisplayLockedThreads.py
@@ -64,11 +64,12 @@ class DisplayLockedThreads(gdb.Command):
                 frame = gdb.selected_frame()
                 while frame:
                     frame.select()
+                    name = frame.name()
                     #print("   {0}".format(frame.name()))
-                    if "pthread_mutex_lock" in frame.name():
+                    if name is not None and "pthread_mutex_lock" in name:
                         trd.waitOnThread = int(gdb.execute("print mutex.__data.__owner", to_string=True).split()[2])
                         #print(threads[-1].waitOnThread)
-                    trd.frames.append(frame.name())
+                    trd.frames.append(name)
                     frame = frame.older()
                 threads[trd.threadId] = trd
 


### PR DESCRIPTION
Fixes #2.